### PR TITLE
[fix] 修复UNITY 2021下System.Nullable<T>.Value偏移计算错误的问题

### DIFF
--- a/hybridclr/Il2CppCompatibleDef.h
+++ b/hybridclr/Il2CppCompatibleDef.h
@@ -140,14 +140,16 @@ namespace hybridclr
 		return il2cpp::vm::Runtime::GetGenericVirtualMethod(result, inflateMethod);
 	}
 
-	inline void* GetNulllableDataOffset(void* nullableObj, uint32_t size)
+	inline void* GetNulllableDataOffset(void* nullableObj, Il2CppClass* nullableClass)
 	{
-		return nullableObj;
+		uint32_t field_offset = nullableClass->fields[0].offset - sizeof(Il2CppObject); // offset of value field
+		return (uint8_t*)nullableObj + field_offset;
 	}
 
-	inline uint8_t* GetNulllableHasValueOffset(void* nullableObj, uint32_t size)
+	inline uint8_t* GetNulllableHasValueOffset(void* nullableObj, Il2CppClass* nullableClass)
 	{
-		return (uint8_t*)nullableObj + size;
+		uint32_t field_offset = nullableClass->fields[1].offset - sizeof(Il2CppObject); // offset of has_value field
+		return (uint8_t*)nullableObj + field_offset;
 	}
 
 	inline Il2CppString* GetKlassFullName(const Il2CppType* type)
@@ -222,14 +224,16 @@ namespace hybridclr
 		return vid.method;
 	}
 
-	inline void* GetNulllableDataOffset(void* nullableObj, uint32_t size)
+	inline void* GetNulllableDataOffset(void* nullableObj, Il2CppClass* nullableClass)
 	{
-		return (uint8_t*)nullableObj + size;
+		uint32_t field_offset = nullableClass->fields[1].offset - sizeof(Il2CppObject); // offset of value field
+		return (uint8_t*)nullableObj + field_offset;
 	}
 
-	inline uint8_t* GetNulllableHasValueOffset(void* nullableObj, uint32_t size)
+	inline uint8_t* GetNulllableHasValueOffset(void* nullableObj, Il2CppClass* nullableClass)
 	{
-		return (uint8_t*)nullableObj;
+		uint32_t field_offset = nullableClass->fields[0].offset - sizeof(Il2CppObject); // offset of has_value field
+		return (uint8_t*)nullableObj + field_offset;
 	}
 
 	inline Il2CppString* GetKlassFullName(const Il2CppType* type)

--- a/hybridclr/interpreter/Interpreter_Execute.cpp
+++ b/hybridclr/interpreter/Interpreter_Execute.cpp
@@ -852,8 +852,8 @@ namespace interpreter
 	{
 		IL2CPP_ASSERT(klass->castClass->size_inited);
 		uint32_t size = klass->castClass->instance_size - sizeof(Il2CppObject);
-		std::memmove(GetNulllableDataOffset(nullableValueTypeObj, size), data, size);
-		*GetNulllableHasValueOffset(nullableValueTypeObj, size) = 1;
+		std::memmove(GetNulllableDataOffset(nullableValueTypeObj, klass), data, size);
+		*GetNulllableHasValueOffset(nullableValueTypeObj, klass) = 1;
 	}
 
 	inline void NewNullableValueType(void* nullableValueTypeObj, void* data, Il2CppClass* klass)
@@ -864,8 +864,7 @@ namespace interpreter
 	inline bool IsNullableHasValue(void* nullableValueObj, Il2CppClass* klass)
 	{
 		IL2CPP_ASSERT(klass->castClass->size_inited);
-		uint32_t size = klass->castClass->instance_size - sizeof(Il2CppObject);
-		return *(GetNulllableHasValueOffset(nullableValueObj, size));
+		return *(GetNulllableHasValueOffset(nullableValueObj, klass));
 	}
 	
 	inline void GetNullableValueOrDefault2StackDataByType(void* dst, void* nullableValueObj, Il2CppClass* klass)
@@ -873,8 +872,8 @@ namespace interpreter
 		Il2CppClass* eleClass = klass->castClass;
 		IL2CPP_ASSERT(eleClass->size_inited);
 		uint32_t size = eleClass->instance_size - sizeof(Il2CppObject);
-		bool notNull = *GetNulllableHasValueOffset(nullableValueObj, size);
-		void* srcData = GetNulllableDataOffset(nullableValueObj, size);
+		bool notNull = *GetNulllableHasValueOffset(nullableValueObj, klass);
+		void* srcData = GetNulllableDataOffset(nullableValueObj, klass);
 
 	LabelGet:
 		IL2CPP_ASSERT(IS_CLASS_VALUE_TYPE(eleClass));
@@ -948,7 +947,7 @@ namespace interpreter
 			}
 			if (notNull)
 			{
-				std::memmove(dst, nullableValueObj, size);
+				std::memmove(dst, srcData, size);
 			}
 			else
 			{
@@ -969,10 +968,10 @@ namespace interpreter
 		IL2CPP_ASSERT(eleClass->size_inited);
 		uint32_t size = eleClass->instance_size - sizeof(Il2CppObject);
 		void* srcData;
-		bool notNull = *GetNulllableHasValueOffset(nullableValueObj, size);
+		bool notNull = *GetNulllableHasValueOffset(nullableValueObj, klass);
 		if (notNull)
 		{
-			srcData = GetNulllableDataOffset(nullableValueObj, size);
+			srcData = GetNulllableDataOffset(nullableValueObj, klass);
 		}
 		else
 		{
@@ -1055,7 +1054,7 @@ namespace interpreter
 				eleClass = eleClass->castClass;
 				goto LabelGet;
 			}
-			std::memmove(dst, nullableValueObj, size);
+			std::memmove(dst, srcData, size);
 			break;
 		}
 		default:


### PR DESCRIPTION
il2cpp生成的Nullable结构体，在UNITY 2021之前和2021之后的版本中，value和hasValue这2个字段的声明顺序是相反的：
``` csharp
// UNITY 2019 - 2020
struct Nullable_1_xxxxx
{
	MyStruct_xxxxx  ___value_0;
	bool ___has_value_1;
}

// UNITY 2021
struct Nullable_1_xxxxx
{
	bool ___hasValue_0;
	MyStruct_xxxxx  ___value_1;
};
```
考虑到内存对齐，实际结构体内存分布大致如下(以64位架构为例)：
```
// UNITY 2019 - 2020
╔══════════════╦══════════════╗
║ value        ║ has_value    ║
╠══════════════╬══════════════╣
║ 16 bytes     ║ 8 bytes      ║
║ 0x00 ~ 0x0f  ║ 0x10 ~ 0x17  ║
╚══════════════╩══════════════╝
// UNITY 2021
╔══════════════╦══════════════╗
║ has_value    ║ value        ║
╠══════════════╬══════════════╣
║ 8 bytes      ║ 16 bytes     ║
║ 0x00 ~ 0x07  ║ 0x08 ~ 0x17  ║
╚══════════════╩══════════════╝
```
再来对照看 `GetNulllableDataOffset` 以及 `GetNulllableHasValueOffset` 原来的实现，可以发现在2021下仅是把两个offset的计算方式简单的做了交换，显然这样实现是有问题的：
```cpp
#if HYBRIDCLR_UNITY_2019 || HYBRIDCLR_UNITY_2020
        // size为value所占内存大小 (nullableClass->eleClass->instance_size - sizeof(Il2CppObject))
	inline void* GetNulllableDataOffset(void* nullableObj, uint32_t size) 
	{
		return nullableObj;
	}

	inline uint8_t* GetNulllableHasValueOffset(void* nullableObj, uint32_t size)
	{
		return (uint8_t*)nullableObj + size;
	}
#elif HYBRIDCLR_UNITY_2021
	inline void* GetNulllableDataOffset(void* nullableObj, uint32_t size)
	{
		return (uint8_t*)nullableObj + size; // 64位架构下，value真实偏移应当是 nullableObj + 8，而不是nullableObj + value对象的size。
	}

	inline uint8_t* GetNulllableHasValueOffset(void* nullableObj, uint32_t size)
	{
		return (uint8_t*)nullableObj;
	}
#else
...
#endif
```

另外考虑到实际情况下内存对齐结果并不是一定的（比如开发者在编译中使用了`#pragma pack`指令），个人建议从`Il2CppClass::fields`中获取对应字段的实际偏移量会相对比较稳妥。
```cpp
// offset of value field in UNITY_2021
uint32_t field_offset = nullableClass->fields[1].offset - sizeof(Il2CppObject); 
```
具体可详见提交。